### PR TITLE
Update AER.py

### DIFF
--- a/AC_1D/AER.py
+++ b/AC_1D/AER.py
@@ -303,7 +303,10 @@ class AER_pop():
         #save_path ='C:\\Users\\yij\\Documents\\1D_aerosol cloud model\\T_array.npy'
         #np.save(save_path, T_array)
         #T_array = np.load('C:\\Users\\yij\\Documents\\1D_aerosol cloud model\\T_array03.npy')
-        #self.T_array = T_array
+        
+        
+        
+        
         logging.debug("length of T_array: %d", len(T_array))
     def _set_aer_conc_fun(self, singular_fun):
         """

--- a/AC_1D/AER.py
+++ b/AC_1D/AER.py
@@ -384,7 +384,7 @@ class AER_pop():
               np.tanh(0.0415 * (Tk - 218.8)) * (53.878 - 1331.22 / Tk - 9.44523 * np.log(Tk) + 0.014025 * Tk)))
              ))-2.4256)* 1e4* s_area
             elif singular_fun == "SW2017":
-             # Oragnic ns fitting from Swarup China et al. (2017)
+             # Organic ns fitting from Swarup China et al. (2017)
                 self.singular_fun = lambda Tk, s_area: \
                     10**(66.90259 * (1-(np.exp(9.550426 - 5723.265 / Tk + 3.53068 * np.log(Tk) -
                     0.00728332 * Tk) /

--- a/AC_1D/AER.py
+++ b/AC_1D/AER.py
@@ -431,7 +431,7 @@ class AER_pop():
 
         if ci_model.prognostic_inp:
             self.ds = self.ds.assign_coords({"T": self.T_array})
-            print("Tvalues",self.ds["T"].values)
+            logging.debug("Tvalues %s", self.ds["T"].values)
             tmp_inp_array, tmp_inp_array_src = \
                 np.zeros((self.ds["height"].size, self.ds["T"].size)), np.zeros((self.ds["T"].size))
         if self.singular_fun.__code__.co_argcount > 1:

--- a/AC_1D/AER.py
+++ b/AC_1D/AER.py
@@ -304,7 +304,7 @@ class AER_pop():
         #np.save(save_path, T_array)
         #T_array = np.load('C:\\Users\\yij\\Documents\\1D_aerosol cloud model\\T_array03.npy')
         #self.T_array = T_array
-        print("length of T_array:", len(T_array))
+        logging.debug("length of T_array: %d", len(T_array))
     def _set_aer_conc_fun(self, singular_fun):
         """
         Set the INP initialization function for the singular approach.

--- a/AC_1D/AER.py
+++ b/AC_1D/AER.py
@@ -292,7 +292,8 @@ class AER_pop():
         if ci_model.ds["T"].min() >= T_max:
             raise RuntimeError('Minimum LES-informed temperature must be larger than %.2f K in'
                                ' singular mode to allow any aerosol to activate' % T_max)
-        #T_min = 0. + np.maximum(ci_model.ds["T"].min().values, 233.15)
+        # The minimum temperature is set to a fixed value (235.15 K) to ensure consistency across model runs.
+        # If a dynamic calculation is needed, consider using the minimum temperature from the model domain.
         T_min = 235.15
 
         T_array = np.array([T_min])

--- a/AC_1D/AER.py
+++ b/AC_1D/AER.py
@@ -294,7 +294,6 @@ class AER_pop():
                                ' singular mode to allow any aerosol to activate' % T_max)
         #T_min = 0. + np.maximum(ci_model.ds["T"].min().values, 233.15)
         T_min = 235.15
-        #T_min=250.3670984
 
         T_array = np.array([T_min])
         while T_array[-1] < T_max:


### PR DESCRIPTION
This document summarizes all changes made to the AER.py. The changes primarily focus on enhancing ice nucleation parameterizations, improving temperature array generation, and adding new singular ice nucleation function options.

1. Enhanced Singular Ice Nucleation Function Options

1.1 New Parameterizations Added (Lines 100-102, 322-324, 356-412)

Six new parameterization options added:
- **PT2022**: Peter et al., Science Advances, 2022
- **SW2017**: Swarup China et al., Journal of Geophysical Research-Atmospheres, 2017  
- **MC2018**: McCluskey et al., Journal of Geophysical Research-Atmospheres, 2018
- **AL2022**: SSA ns fitting with upper/lower bound variants
- **0.5PT2022** and **0.5MC2018**: Half-scale versions for sensitivity testing

1.2 Purpose

These additions provide more options for IMF parameterizations, scale factor testing capabilities, additional aerosol type coverage, and integration of recent research (2018-2022 publications).

2. Temperature Array Generation Improvements

2.1 Modified `_set_T_array` Method (Lines 276-307)

Parameters changed for finer resolution:
- dT0: 0.1K → 0.0001K
- dT_exp: 1.05 → 1.001
- T_min: Dynamic calculation → Fixed at 235.15K Finer resolution can help remove "noise" like behaviors in nucleation rate, resulting smoother figures. More broad and fixed temperature suggested by Nicole Riemer, make sure that each time we use the same temperature array covering all possible situations.

Debug features added:
- Array length monitoring: `print("length of T_array:", len(T_array))`

3. Enhanced Debugging and Diagnostics

3.1 Debug Print Statements (Lines 307, 434)

Added temperature array diagnostics:
- `print("length of T_array:", len(T_array))`
- `print("Tvalues", self.ds["T"].values)`

4. Standard Liter Conversion Fix

4.1 Density Reference Update (Line 469)

Changed density reference from surface values `[0, 0]` to top-of-domain values `[-1, 0]` for standard liter to SI liter conversion in source INP concentrations.